### PR TITLE
DS1340 Trickle Charge Register Initialization Patch

### DIFF
--- a/arch/arm/boot/dts/am335x-pepper-43c.dts
+++ b/arch/arm/boot/dts/am335x-pepper-43c.dts
@@ -105,8 +105,8 @@
 	ds_rtc: ds1340@68 {
 		compatible = "dallas,ds1340";
 		reg = <0x68>;
+		trickle-resistor-ohms = <2000>;
 	};
-
 };
 
 &i2c1 {

--- a/arch/arm/boot/dts/am335x-pepper-43r.dts
+++ b/arch/arm/boot/dts/am335x-pepper-43r.dts
@@ -105,8 +105,8 @@
 	ds_rtc: ds1340@68 {
 		compatible = "dallas,ds1340";
 		reg = <0x68>;
+		trickle-resistor-ohms = <2000>;
 	};
-
 };
 
 &i2c1 {

--- a/arch/arm/boot/dts/am335x-pepper-dvi.dts
+++ b/arch/arm/boot/dts/am335x-pepper-dvi.dts
@@ -84,6 +84,7 @@
 	ds_rtc: ds1340@68 {
 		compatible = "dallas,ds1340";
 		reg = <0x68>;
+		trickle-resistor-ohms = <2000>;
 	};
 };
 

--- a/drivers/rtc/rtc-ds1307.c
+++ b/drivers/rtc/rtc-ds1307.c
@@ -151,6 +151,7 @@ static struct chip_desc chips[last_ds_type] = {
 	},
 	[ds_1340] = {
 		.trickle_charger_reg = 0x08,
+		.do_trickle_setup = &do_trickle_setup_ds1339,
 	},
 	[ds_1388] = {
 		.trickle_charger_reg = 0x0a,


### PR DESCRIPTION
Added line in rtc-ds1307 for DS1340 variant in order to run
trickle charge initialization. Added one line in Pepper
device trees to set resistor value.

Signed-off-by: Michael Lew <michael.lew@gumstix.com>